### PR TITLE
-P option is added to the avrdude command only if it is specified after ...

### DIFF
--- a/avrdude-scp
+++ b/avrdude-scp
@@ -12,8 +12,8 @@ function parseRemote {
   HOST=${arr[0]}
   DEVICE=${arr[1]}
 
-  if [ -z "$DEVICE" ]; then
-    printf "\\n[$ME] Programmer port not specified"
+  if [[ -z "$DEVICE" ]]; then
+    printf "[$ME] Programmer port not specified"
   else
     # Put the device into the params for the remote.
     PARAMS="$PARAMS -P $DEVICE"
@@ -110,7 +110,10 @@ for i in "$@"; do
 done
 
 connect
-resetBaud
+
+if [[ ! -z "$DEVICE" ]]; then
+  resetBaud
+fi
 
 if [[ $MEM_OP_TYPE -eq 0 ]]; then
   printf "\\n[$ME] Reading from board..."


### PR DESCRIPTION
I am using a programmer for which I do not want to specify the -P option. I have added a check to detect if the -P given to avrdude-scp contains an actual programmer port or not.
