### PR TITLE
Executing non-memory ops now set the correct exit status.

### DIFF
--- a/avrdude-scp
+++ b/avrdude-scp
@@ -254,7 +254,9 @@ if connect; then
     if pre_command; then
       printf "[$ME] Executing avrdude...\\n"
       if execute; then
-        post_command
+        if post_command; then
+          result=0
+        fi
       fi
     fi
   fi


### PR DESCRIPTION
Exit status was not correct when no operations were run(running avrdude to cause an MCU reset for example).
